### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM aergo/ship
+
+WORKDIR /contracts
+COPY . .
+RUN ./scripts/publish.sh


### PR DESCRIPTION
This can be useful for building Docker images for other smart contracts which depend on modules such as `typecheck`.